### PR TITLE
Encode substitution @ to @@ in source file.

### DIFF
--- a/ift1015/codeboot.sh
+++ b/ift1015/codeboot.sh
@@ -2,5 +2,5 @@
 
 CODEBOOT="http://www-labs.iro.umontreal.ca/~codeboot/codeboot"
 
-FILE="@C$(basename "$1")@0$(sed ':a;N;$!ba;s/\r//g;s/\n/@N/g' "$1")@E"
+FILE="@C$(basename "$1")@0$(sed ':a;N;$!ba;s/@/@@/g;s/\r//g;s/\n/@N/g' "$1")@E"
 xdg-open "$CODEBOOT/query.cgi?REPLAY=$(base64 <<< $FILE)"


### PR DESCRIPTION
"@" must be encode as "@@" to actually get "@" in codeboot.